### PR TITLE
Editorial fixes for the question

### DIFF
--- a/question.md
+++ b/question.md
@@ -5,9 +5,10 @@ Thank you to everyone who participated in [Overhauling our community's closure r
 
 It appears that we have quite a few ideas about closure reasons we'd like to add as well as updating the wording for a few of the existing reasons. As mentioned in the previous post, we are currently using __all 5__ of our Community Specific Closure Reason slots.
 
-In order to move forward and potentially add a new reason, we first need to free up a space. I propose we retire our (2) specific off-topic closure reasons for specifically Server Fault and Super User in favour of something more general.
+In order to move forward and potentially add a new reason, we first need to free up slots. I propose we retire our (2) specific off-topic closure reasons, specifically, Server Fault and Super User in favour of a more general one.
 
-See the existing proposals:
+Please review the existing proposals:
+
  - [Answer to: Avoiding overly specific site referrals for general computing and sysadmin questions](https://meta.stackoverflow.com/a/313265)
  - [Remove the mention of "Super User" from the standard off-topic close reasons](https://meta.stackoverflow.com/q/277872)
  - [Answer to: Make description of “community-specific reason” close reason more clear](https://meta.stackoverflow.com/a/412865) (See Blatantly off-topic)
@@ -19,15 +20,14 @@ See the existing proposals:
 
 There are more than a few different ideas about what the wording for this reason should be.
 
-Reminder that there are __5 fields__ that need to be set for this new combined reason each have a 500-character limit excluding the first which has a 100-character limit from [Catjia's](https://meta.stackexchange.com/users/284336) answer to [Should we update/clarify our help center with respect to other sites and teams?](https://meta.stackexchange.com/a/362584):
+Reminder that there are __5 fields__ that need to be set for this new combined reason; each have a 500-character limit excluding the first which has a 100-character limit (from [Catjia's](https://meta.stackexchange.com/users/284336) answer to [Should we update/clarify our help center with respect to other sites and teams?](https://meta.stackexchange.com/a/362584)):
 
 > 1. **Brief description** (100 characters but should be just a few words) - this is the Bold part of the close reason that appears in the close vote UI when closers are voting to close the post.
-> 2. **Usage guidance** - this tells close voters when to use this close reason. It should clarify any edge cases and help voters feel certain they're choosing the correct reason
+> 2. **Usage guidance** - this tells close voters when to use the close reason. It should clarify any edge cases and help voters feel certain they're choosing the correct reason.
 > 3. **Post notice close description** - visible to all users. This is a general note about why the question was closed. It can include links to resources that explain the site's policy. It should always start and end with the same thing "This question was closed because it is ... It is not currently accepting answers."
-> 4. **Post owner guidance** - this additional information appears in the post notice but only for the asker of the question. It should contain detailed information about how they can improve their post and may also include links to help here on meta or in the help center.
-> 5. **Privileged user guidance** - this additional information appears in the post notice but only for users with the close/reopen privilege. It is designed to help them know how to guide the asker in improving their question or inform them when the question should be reopened.
+> 4. **Post owner guidance** - this additional information appears in the post notice but only for the asker of the question. It should contain detailed information about how they can improve their post (if possible) and may also include links to help here on meta or in the [help center](https://stackoverflow.com/help).
+> 5. **Privileged user guidance** - this additional information appears in the post notice but only for users with the "cast close and reopen votes" [privilege](https://stackoverflow.com/help/privileges/close-questions). It is designed to help them know how to guide the asker in improving their question or inform them when the question should be reopened.
 
-You can review our current closure reasons with [this SEDE query](https://data.stackexchange.com/stackoverflow/query/1573733)
+You can review our current closure reasons with [this SEDE query](https://data.stackexchange.com/stackoverflow/query/1573733).
 
-
-I would like to ask the community to propose options for _complete_ closure guidance on our new closure reason. Then have the highest scoring answer converted into the new closure reason.
+I would like to ask the community to propose options for _complete_ guidance on our new closure reason. Then have the highest scoring answer converted into the new closure reason.


### PR DESCRIPTION
This PR makes several minor editorial fixes to the question.

The only significant change is in the field #5 description where I think it makes sense to link to the CV/RV privilege page and refer to it by its official name.